### PR TITLE
Set default fsType to EXT4

### DIFF
--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -208,6 +208,7 @@ spec:
             - --timeout=2m5s
             - --leader-election
             - --leader-election-namespace=$(POD_NAMESPACE)
+            - --default-fstype=ext4
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
If fstype is not set as a parameter in the storageClass then default to ext4 to ensure volume permissions are configured correctly.

https://github.com/harvester/harvester/issues/1369