### PR TITLE
Disable volume RWX mode support

### DIFF
--- a/pkg/csi/controller_server.go
+++ b/pkg/csi/controller_server.go
@@ -51,7 +51,6 @@ func NewControllerServer(coreClient ctlv1.Interface, virtClient kubecli.Kubevirt
 		accessModes: getVolumeCapabilityAccessModes(
 			[]csi.VolumeCapability_AccessMode_Mode{
 				csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-				csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 			}),
 	}
 }


### PR DESCRIPTION
**Description:**
Disable csi driver volume RWX mode support since LH block device volume doesn't support real RWX mode, it was used just for live migration and data synchronization.

**Validation steps:**
1. Spin up the guest k8s cluster via the Harvester node driver(e.g RKE2 with k8s v1.22.7+rke2r2) and the cloud provider is set to `Harvester`.
2. once the cluster is up and running path the embedded csi driver image with custom build e.g. `docker.io/guangbo/harvester-csi-driver:master-0415`
3. Creating PVCs on the `Storage -> PersistentVolumeClaims` page:
    - PVC with the mode of  `Read-Write-Many` or `Read-Only-Many` will be stuck on pending and the event will contain an appropriate error message.
    - PVC with the mode of `Read-Write-Only` will works as expected (the same rules apply to the deployment creation)
<img width="627" alt="image" src="https://user-images.githubusercontent.com/4569037/163526441-f37c372e-74b9-4487-b63d-21e3a9b551c6.png">


Related Issue:
https://github.com/harvester/harvester/issues/2151