### PR TITLE
move driver base imge to bci

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:20.04
+FROM registry.suse.com/bci/bci-base:15.4
 
-RUN apt-get update && apt-get install -y curl vim nfs-common iproute2 dnsutils iputils-ping zip xfsprogs
+RUN zypper update --no-confirm && \
+    zypper install --no-confirm curl iproute2 iputils nfs-client vim xfsprogs zip
 
 COPY bin/harvester-csi-driver /usr/bin/
 


### PR DESCRIPTION
Move csi driver base image to `bci-base:15.4` from alpine.

Issue [#1995](https://github.com/harvester/harvester/issues/1995)