### PR TITLE
Allow specifying storageclass defined in the host cluster

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,11 +4,12 @@ import (
 	_ "net/http/pprof"
 	"os"
 
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
 	"github.com/harvester/harvester-csi-driver/pkg/config"
 	"github.com/harvester/harvester-csi-driver/pkg/csi"
 	"github.com/harvester/harvester-csi-driver/pkg/version"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
 )
 
 var (
@@ -36,7 +37,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:        "host-storage-class",
-			Value:       "longhorn",
+			Value:       "",
 			EnvVar:      "HOST_STORAGE_CLASS",
 			Usage:       "storage class of volumes created in the host cluster",
 			Destination: &cfg.HostStorageClass,

--- a/pkg/csi/server.go
+++ b/pkg/csi/server.go
@@ -47,7 +47,6 @@ func (s *NonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer, c
 
 	go s.serve(endpoint, ids, cs, ns)
 
-	return
 }
 
 func (s *NonBlockingGRPCServer) Wait() {
@@ -110,7 +109,7 @@ func parseEndpoint(ep string) (string, string, error) {
 			return s[0], s[1], nil
 		}
 	}
-	return "", "", fmt.Errorf("Invalid endpoint: %v", ep)
+	return "", "", fmt.Errorf("invalid endpoint: %v", ep)
 }
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {


### PR DESCRIPTION
related issues: https://github.com/harvester/harvester/issues/3052

Now we do not assign the default StorageClass for harvester-csi-driver.
Also, parse the parameter key `hostStorageClass` to a specific `StorageClass` on PVC creating.

Test Plan is described as below:

**Preparation:** 

**NOTE**: The preparation would be done on the host harvester cluster.
Please create the new clusterrole `harvesterhci.io:csi-driver` by following manifest:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
    app.kubernetes.io/component: apiserver
    app.kubernetes.io/name: harvester
    app.kubernetes.io/part-of: harvester
  name: harvesterhci.io:csi-driver
rules:
- apiGroups:
  - storage.k8s.io
  resources:
  - storageclasses
  verbs:
  - get
  - list
  - watch
```

Then create the clusterrolebinding to associate with this. You could refer to the following manifest.
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: <guest cluster namespace>-<guest cluster name>
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: harvesterhci.io:csi-driver
subjects:
- kind: ServiceAccount
  name: <your guest cluster name>
  namespace: <your guest cluster namespace>
```

**Test cases**:
- Verify the Default StorageClass behavior
1. Create the volume `vol001` with the default StorageClass on the Guest Cluster
2. Check the `vol001` is created with the Default StorageClass on the Host Harvester Cluster. 

- Verify the user-defined StorageClass behavior
1. Create a new StorageClass `test` on the Host Harvester Cluster.
2. Create a new StorageClass using the following manifest on the Guest Cluster.

    ``` yaml
    allowVolumeExpansion: true
    apiVersion: storage.k8s.io/v1
    kind: StorageClass
    metadata:
      name: harvester-SC-test
    provisioner: driver.harvesterhci.io
    reclaimPolicy: Delete
    volumeBindingMode: Immediate
    parameters:
      hostStorageClass: test
    ```

3. Create the volume `vol002` with the above StorageClass on the Guest Cluster.
4. Check the `vol002` is created with the `test` StorageClass on the Host Harvester Cluster.

- Verify the non-exists StorageClass behavior
1. Create a new StorageClass using the following manifest on the Guest Cluster.

    ``` yaml
    allowVolumeExpansion: true
    apiVersion: storage.k8s.io/v1
    kind: StorageClass
    metadata:
      name: harvester-SC-test-non-exist
    provisioner: driver.harvesterhci.io
    reclaimPolicy: Delete
    volumeBindingMode: Immediate
    parameters:
      hostStorageClass: non-storageclass
    ```

2. Create the volume `vol003` with the above StorageClass on the Guest Cluster.
3. Check the `vol002` is on the status `pending` and you can see some error log on the harvester-csi-driver.