### PR TITLE
scripts: rename generate_addon to generate_addon_csi

### DIFF
--- a/deploy/generate_addon_csi.sh
+++ b/deploy/generate_addon_csi.sh
@@ -10,8 +10,8 @@ if [[ -z "$1" ]] || [[ -z "$2" ]]; then
 fi
 
 SERVICE_ACCOUNT_NAME=$1
-ROLE_BINDING_NAME=$1
-NAMESPACE="$2"
+NAMESPACE=$2
+ROLE_BINDING_NAME=$NAMESPACE-$SERVICE_ACCOUNT_NAME
 CLUSTER_ROLE_NAME="harvesterhci.io:cloudprovider"
 KUBECFG_FILE_NAME="./tmp/kube/k8s-${SERVICE_ACCOUNT_NAME}-${NAMESPACE}-conf"
 TARGET_FOLDER="./tmp/kube"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
According to https://github.com/harvester/harvester/issues/2755, we may rename the generate_addon.sh on CSI. That would clarify CPI/CSI scripts.

**Solution:**
Rename the generate_addon.sh to generate_addon_csi.sh

**Related Issue:**
https://github.com/harvester/harvester/issues/2755

**Test plan:**
make sure CPI/CSI is still okay with manually deploying

Also, we rename the roleBinding name. That would make consistency with rke2 harvester provisioner.