### PR TITLE
deploy: correct the cloud-provider-config path

### DIFF
--- a/deploy/generate_addon_csi.sh
+++ b/deploy/generate_addon_csi.sh
@@ -176,7 +176,7 @@ generate_cloud_config() {
   - encoding: b64
     content: ${KUBECONFIG_B64}
     owner: root:root
-    path: /etc/kubernetes/cloud-config
+    path: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
     permissions: '0644'"
   rm -r ${TARGET_FOLDER}
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
We should use the default cloud-provider-config path instead the default kubernetes path

**Solution:**
correct the cloud-provider-config path on the cloud-init data content

**Related Issue:**
https://github.com/harvester/harvester/issues/2755

**Test plan:**
no need