### PR TITLE
Manual deployment: fix volume creations in non-default namespaces

### DIFF
--- a/deploy/generate_addon_csi.sh
+++ b/deploy/generate_addon_csi.sh
@@ -49,7 +49,7 @@ create_service_account() {
 
 create_rolebinding() {
   echo -e "\\nCreating a rolebinding in ${NAMESPACE} namespace: ${ROLE_BINDING_NAME}"
-  kubectl create rolebinding ${ROLE_BINDING_NAME} --serviceaccount=${NAMESPACE}:${SERVICE_ACCOUNT_NAME} --clusterrole=${CLUSTER_ROLE_NAME} --dry-run -o yaml | kubectl apply -f -
+  kubectl create rolebinding ${ROLE_BINDING_NAME} --serviceaccount=${NAMESPACE}:${SERVICE_ACCOUNT_NAME} --clusterrole=${CLUSTER_ROLE_NAME} --namespace=${NAMESPACE} --dry-run -o yaml | kubectl apply -f -
 }
 
 get_secret_name_from_service_account() {


### PR DESCRIPTION
Specify the role-binding namespace for guest clusters. The current implementation always creates the role-binding in the `default` name space.

