### PR TITLE
Discover node ID from KubeVirt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,8 +51,9 @@ require (
 	github.com/rancher/wrangler v0.8.11
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli v1.22.2
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/net v0.7.0
-	golang.org/x/sys v0.5.0
+	golang.org/x/sys v0.13.0
 	google.golang.org/grpc v1.40.0
 	k8s.io/api v0.24.9
 	k8s.io/apimachinery v0.24.9
@@ -86,7 +87,7 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/gorilla/handlers v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -470,8 +470,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -1085,6 +1085,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20210220032938-85be41e4509f/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -1317,8 +1319,8 @@ golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
-golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
@@ -1427,7 +1429,6 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=

--- a/pkg/sysfsnet/interfaces_linux.go
+++ b/pkg/sysfsnet/interfaces_linux.go
@@ -1,0 +1,60 @@
+package sysfsnet
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var sysClassNet = "/sys/class/net"
+
+type Interface struct {
+	HardwareAddr net.HardwareAddr
+}
+
+func Interfaces() ([]Interface, error) {
+	dents, err := os.ReadDir(sysClassNet)
+	if err != nil {
+		return nil, err
+	}
+
+	ifaces := make([]Interface, 0, 16)
+
+	readMACFromFile := func(s string) (string, error) {
+		f, err := os.Open(s)
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		if err != nil {
+			return "", err
+		}
+		defer f.Close()
+
+		r := bufio.NewScanner(bufio.NewReader(f))
+		r.Split(bufio.ScanLines)
+		_ = r.Scan()
+		return r.Text(), nil
+	}
+
+	for _, dentry := range dents {
+		hwText, err := readMACFromFile(filepath.Join(sysClassNet, dentry.Name(), "address"))
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		hwText = strings.TrimSpace(hwText)
+		hw, err := net.ParseMAC(hwText)
+		if err != nil {
+			continue
+		}
+
+		ifaces = append(ifaces, Interface{HardwareAddr: hw})
+	}
+
+	return ifaces, nil
+}

--- a/pkg/sysfsnet/interfaces_test.go
+++ b/pkg/sysfsnet/interfaces_test.go
@@ -1,0 +1,48 @@
+package sysfsnet
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestInterfaces(t *testing.T) {
+	origDir := sysClassNet
+	sysClassNet = t.TempDir()
+	defer func() { sysClassNet = origDir }()
+
+	dir := map[string]string{
+		"eth0": "ce:ce:ce:ce:ce:ce",
+		"lo":   "00:00:00:00:00:00",
+	}
+
+	for subdir, address := range dir {
+		path := filepath.Join(sysClassNet, subdir, "address")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("os.MkdirAll %q want err=<nil>, got err=%v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(address), 0o644); err != nil {
+			t.Fatalf("os.WriteFile %q want err=<nil>, got err=%v", path, err)
+		}
+	}
+
+	ifaces, err := Interfaces()
+	if err != nil {
+		t.Fatalf("want err=<nil>, got err=%v", err)
+	}
+
+	got := make(map[string]struct{})
+	for _, iface := range ifaces {
+		got[iface.HardwareAddr.String()] = struct{}{}
+	}
+
+	want := map[string]struct{}{
+		"ce:ce:ce:ce:ce:ce": {},
+		"00:00:00:00:00:00": {},
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("want MACs=%v, got MACs=%v", want, got)
+	}
+}


### PR DESCRIPTION
**Problem:**

harvester-csi-driver previously assumed the Harvester VM's name was the hostname, but this is not necessarily always the case. When the cluster operator creates the VM and specifically makes the hostname different from the VM name, harvester-csi-driver would not be able to select the correct VMI based on just the hostname.

**Solution:**

To fix this, discover the VMI name by comparing the MAC addresses seen from within the guest to the MAC addresses described in the VMI.

**Related Issue:** https://github.com/harvester/harvester/issues/4396

**Test plan:**

1. Create a Harvester VM with a hostname that is specifically different than the Harvester VM name (i.e., in cloud-init `hostname: xyz`)
2. Install k3s on the VM
3. Install harvester-csi-driver on the guest cluster running in the VM
4. Create a PVC:

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: harv-pvc-example
spec:
  storageClassName: harvester
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 32Gi
```

5. Confirm PVC status:

```console
$ kubectl get pvc
NAME               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
harv-pvc-example   Bound    pvc-667350b0-82fe-4ef3-b884-8c6418f21ce2   32Gi       RWO            harvester      2s
```

6. In Harvester dashboard, click "Volumes", and confirm the corresponding volume exists and is Ready.
7. Mount the PVC to a pod

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:latest
          volumeMounts:
            - mountPath: /harvester
              name: harv
      volumes:
        - name: harv
          persistentVolumeClaim:
            claimName: harv-pvc-example
```

8. In Harvester dashboard, click "Volumes" and confirm the volume has been hotplugged to your guest k8s cluster VM