### PR TITLE
Replace ENDPOINT address with VIP instead of kubeconfig value

### DIFF
--- a/deploy/generate_addon_csi.sh
+++ b/deploy/generate_addon_csi.sh
@@ -109,8 +109,12 @@ set_kube_config_values() {
   CLUSTER_NAME=$(kubectl config get-contexts "$context" | awk '{print $3}' | tail -n 1)
   echo "Cluster name: ${CLUSTER_NAME}"
 
-  ENDPOINT=$(kubectl config view \
-    -o jsonpath="{.clusters[?(@.name == \"${CLUSTER_NAME}\")].cluster.server}")
+  ENDPOINT=$(echo "https://"$(kubectl -n harvester-system get cm vip -o jsonpath="{.data.ip}")":6443")
+  curl -k -ss $ENDPOINT 2>&1 > /dev/null
+  if [ $? -ne 0 ]; then
+        echo "ENDPOINT not reachable!"
+        exit 1
+  fi  
   echo "Endpoint: ${ENDPOINT}"
 
   # Set up the config


### PR DESCRIPTION
**Problem:**
If you run the generate_addon_csi.sh script via Rancher provided kubeconfig or via SSH from the Harvester CP node, the following line will give you an incorrect kubectl server. For example:
```
++ kubectl config view -o 'jsonpath={.clusters[?(@.name == "default")].cluster.server}'
+ ENDPOINT=https://127.0.0.1:6443
```


**Solution:**
I'm extracting the VIP address of the Harvester cluster.

**Related Issue:**
https://github.com/harvester/harvester/issues/6118