### PR TITLE
common: bump golang 1.22.7 and bci image 15.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester-csi-driver
 
-go 1.22.5
+go 1.22.7
 
 replace (
 	github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM registry.suse.com/bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-base:15.6
 
 RUN zypper update --no-confirm && \
     zypper install --no-confirm curl iproute2 iputils nfs-client vim xfsprogs e2fsprogs zip


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
bump golang 1.22.7 and bci image 15.6

**Solution:**
bump golang 1.22.7 and bci image 15.6

**Related Issue:**
https://github.com/harvester/harvester/issues/6568

**Test plan:**
