### PR TITLE
controller: Do not check volume status if we do not have permission

### DIFF
--- a/pkg/csi/manager.go
+++ b/pkg/csi/manager.go
@@ -115,7 +115,7 @@ func (m *Manager) Run(cfg *config.Config) error {
 	}
 
 	m.ids = NewIdentityServer(driverName, version.FriendlyVersion())
-	m.ns = NewNodeServer(coreClient.Core().V1(), virtClient, lhclient, harvNetworkFSClient, nodeID, namespace, restConfig.Host)
+	m.ns = NewNodeServer(coreClient.Core().V1(), virtClient, harvNetworkFSClient, nodeID, namespace, restConfig.Host)
 	m.cs = NewControllerServer(coreClient.Core().V1(), storageClient.Storage().V1(), virtClient, lhclient, harvNetworkFSClient, namespace, cfg.HostStorageClass)
 
 	// Create GRPC servers

--- a/pkg/csi/node_server.go
+++ b/pkg/csi/node_server.go
@@ -12,7 +12,6 @@ import (
 	common "github.com/harvester/go-common/common"
 	networkfsv1 "github.com/harvester/networkfs-manager/pkg/apis/harvesterhci.io/v1beta1"
 	harvnetworkfsset "github.com/harvester/networkfs-manager/pkg/generated/clientset/versioned"
-	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
 	ctlv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
@@ -36,11 +35,10 @@ type NodeServer struct {
 	nodeID          string
 	caps            []*csi.NodeServiceCapability
 	vip             string
-	lhClient        *lhclientset.Clientset
 	harvNetFSClient *harvnetworkfsset.Clientset
 }
 
-func NewNodeServer(coreClient ctlv1.Interface, virtClient kubecli.KubevirtClient, lhClient *lhclientset.Clientset, harvNetFSClient *harvnetworkfsset.Clientset, nodeID string, namespace, vip string) *NodeServer {
+func NewNodeServer(coreClient ctlv1.Interface, virtClient kubecli.KubevirtClient, harvNetFSClient *harvnetworkfsset.Clientset, nodeID string, namespace, vip string) *NodeServer {
 	return &NodeServer{
 		coreClient: coreClient,
 		virtClient: virtClient,
@@ -52,7 +50,6 @@ func NewNodeServer(coreClient ctlv1.Interface, virtClient kubecli.KubevirtClient
 				csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 			}),
 		vip:             vip,
-		lhClient:        lhClient,
 		harvNetFSClient: harvNetFSClient,
 	}
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The new csi driver did not work if the corresponding clusterrole did not have the correct permission.

**Solution:**
Skip the volume status checking if the clusterrole did not have corresponding permission.

**Related Issue:**
https://github.com/harvester/harvester/issues/6849

**Test plan:**
1. create v1.3.2 cluster
2. use the CSI driver with this PR. The PVC operation should work as usual.