### PR TITLE
Handle non-directory entries in /sys/class/net

### DIFF
--- a/pkg/sysfsnet/interfaces_linux.go
+++ b/pkg/sysfsnet/interfaces_linux.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 var sysClassNet = "/sys/class/net"
@@ -47,11 +49,13 @@ func Interfaces() ([]Interface, error) {
 		// os.Stat to follow symlinks and return the info of the target
 		info, err := os.Stat(entryPath)
 		if err != nil {
+			logrus.Warnf("Unable to stat %s: %v", entryPath, err)
 			continue
 		}
 
 		// os.FileInfo.IsDir to check if the entry is a directory
 		if !info.IsDir() {
+			logrus.Warnf("Skipping non-directory entry %s", entryPath)
 			continue
 		}
 
@@ -66,6 +70,7 @@ func Interfaces() ([]Interface, error) {
 		hwText = strings.TrimSpace(hwText)
 		hw, err := net.ParseMAC(hwText)
 		if err != nil {
+			logrus.Warnf("Unable to parse MAC %s: %v", hwText, err)
 			continue
 		}
 

--- a/pkg/sysfsnet/interfaces_linux.go
+++ b/pkg/sysfsnet/interfaces_linux.go
@@ -25,18 +25,18 @@ func Interfaces() ([]Interface, error) {
 	readMACFromFile := func(s string) (string, error) {
 
 		// Check if parent exists and is a directory
-		parent := filepath.Dir(s)
-		info, err := os.Stat(parent)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return "", nil
-			}
-			return "", err
-		}
+		// parent := filepath.Dir(s)
+		// info, err := os.Stat(parent)
+		// if err != nil {
+		// 	if os.IsNotExist(err) {
+		// 		return "", nil
+		// 	}
+		// 	return "", err
+		// }
 
-		if !info.IsDir() {
-			return "", nil
-		}
+		// if !info.IsDir() {
+		// 	return "", nil
+		// }
 
 		f, err := os.Open(s)
 
@@ -55,6 +55,11 @@ func Interfaces() ([]Interface, error) {
 	}
 
 	for _, dentry := range dents {
+
+		if !dentry.IsDir() {
+			continue
+		}
+
 		hwText, err := readMACFromFile(filepath.Join(sysClassNet, dentry.Name(), "address"))
 		if os.IsNotExist(err) {
 			continue

--- a/pkg/sysfsnet/interfaces_linux.go
+++ b/pkg/sysfsnet/interfaces_linux.go
@@ -25,9 +25,7 @@ func Interfaces() ([]Interface, error) {
 	ifaces := make([]Interface, 0, 16)
 
 	readMACFromFile := func(s string) (string, error) {
-
 		f, err := os.Open(s)
-
 		if os.IsNotExist(err) {
 			return "", nil
 		}
@@ -43,7 +41,6 @@ func Interfaces() ([]Interface, error) {
 	}
 
 	for _, dentry := range dents {
-
 		entryPath := filepath.Join(sysClassNet, dentry.Name())
 
 		// os.Stat to follow symlinks and return the info of the target

--- a/pkg/sysfsnet/interfaces_linux.go
+++ b/pkg/sysfsnet/interfaces_linux.go
@@ -24,20 +24,6 @@ func Interfaces() ([]Interface, error) {
 
 	readMACFromFile := func(s string) (string, error) {
 
-		// Check if parent exists and is a directory
-		// parent := filepath.Dir(s)
-		// info, err := os.Stat(parent)
-		// if err != nil {
-		// 	if os.IsNotExist(err) {
-		// 		return "", nil
-		// 	}
-		// 	return "", err
-		// }
-
-		// if !info.IsDir() {
-		// 	return "", nil
-		// }
-
 		f, err := os.Open(s)
 
 		if os.IsNotExist(err) {
@@ -56,11 +42,20 @@ func Interfaces() ([]Interface, error) {
 
 	for _, dentry := range dents {
 
-		if !dentry.IsDir() {
+		entryPath := filepath.Join(sysClassNet, dentry.Name())
+
+		// os.Stat to follow symlinks and return the info of the target
+		info, err := os.Stat(entryPath)
+		if err != nil {
 			continue
 		}
 
-		hwText, err := readMACFromFile(filepath.Join(sysClassNet, dentry.Name(), "address"))
+		// os.FileInfo.IsDir to check if the entry is a directory
+		if !info.IsDir() {
+			continue
+		}
+
+		hwText, err := readMACFromFile(filepath.Join(entryPath, "address"))
 		if os.IsNotExist(err) {
 			continue
 		}

--- a/pkg/sysfsnet/interfaces_linux.go
+++ b/pkg/sysfsnet/interfaces_linux.go
@@ -23,7 +23,23 @@ func Interfaces() ([]Interface, error) {
 	ifaces := make([]Interface, 0, 16)
 
 	readMACFromFile := func(s string) (string, error) {
+
+		// Check if parent exists and is a directory
+		parent := filepath.Dir(s)
+		info, err := os.Stat(parent)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", nil
+			}
+			return "", err
+		}
+
+		if !info.IsDir() {
+			return "", nil
+		}
+
 		f, err := os.Open(s)
+
 		if os.IsNotExist(err) {
 			return "", nil
 		}

--- a/pkg/sysfsnet/interfaces_test.go
+++ b/pkg/sysfsnet/interfaces_test.go
@@ -60,5 +60,4 @@ func TestInterfaces(t *testing.T) {
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("want MACs=%v, got MACs=%v", want, got)
 	}
-
 }

--- a/pkg/sysfsnet/interfaces_test.go
+++ b/pkg/sysfsnet/interfaces_test.go
@@ -13,8 +13,8 @@ func TestInterfaces(t *testing.T) {
 	defer func() { sysClassNet = origDir }()
 
 	dir := map[string]string{
-		"eth0": "ce:ce:ce:ce:ce:ce",
-		"lo":   "00:00:00:00:00:00",
+		"eth0":  "ce:ce:ce:ce:ce:ce",
+		"lo":    "00:00:00:00:00:00",
 		"bond0": "aa:00:00:00:00:11",
 	}
 

--- a/pkg/sysfsnet/interfaces_test.go
+++ b/pkg/sysfsnet/interfaces_test.go
@@ -27,6 +27,11 @@ func TestInterfaces(t *testing.T) {
 		}
 	}
 
+	nonDirPath := filepath.Join(sysClassNet, "bonding_masters")
+	if err := os.WriteFile(nonDirPath, []byte(""), 0o644); err != nil {
+		t.Fatalf("os.WriteFile %q want err=<nil>, got err=%v", nonDirPath, err)
+	}
+
 	ifaces, err := Interfaces()
 	if err != nil {
 		t.Fatalf("want err=<nil>, got err=%v", err)
@@ -44,5 +49,10 @@ func TestInterfaces(t *testing.T) {
 
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("want MACs=%v, got MACs=%v", want, got)
+	}
+
+	// Ensure non-directory entry is ignored
+	if _, exists := got[""]; exists {
+		t.Fatalf("non-directory entry was incorrectly processed")
 	}
 }

--- a/pkg/sysfsnet/interfaces_test.go
+++ b/pkg/sysfsnet/interfaces_test.go
@@ -13,9 +13,11 @@ func TestInterfaces(t *testing.T) {
 	defer func() { sysClassNet = origDir }()
 
 	dir := map[string]string{
-		"eth0":  "ce:ce:ce:ce:ce:ce",
-		"lo":    "00:00:00:00:00:00",
-		"bond0": "aa:00:00:00:00:11",
+		"eth0":   "ce:ce:ce:ce:ce:ce",
+		"lo":     "00:00:00:00:00:00",
+		"bond0":  "aa:00:00:00:00:11",
+		"dummy0": "invalid", // invalid MAC address should be skipped
+		"dummy1": "",        // empty MAC address should be skipped
 	}
 
 	for subdir, address := range dir {
@@ -28,9 +30,8 @@ func TestInterfaces(t *testing.T) {
 		}
 	}
 
-	// Test for non-directory entry
 	nonDir := map[string]string{
-		"bonding_masters": "+bond0",
+		"bonding_masters": "+bond0", // non-directory should be skipped
 	}
 
 	for subdir, content := range nonDir {


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
If non-directory entries are in /sys/class/net - the driver fails to enumerate interface macs. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Before attempting to open /sys/class/net/[interface]/address, checks if /sys/class/net/[interface] is a directory. If it is not, ignore it and continue enumerating the interfaces 

**Related Issue:**

https://github.com/harvester/harvester/issues/7232

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

All test pass running `make ci`, built and pushed and tested in cluster with the following logs: 

```
time="2024-12-24T02:13:22Z" level=info msg="Current node macs: [96:61:c4:bd:44:df 86:39:76:2a:5b:0e d2:87:e6:c1:44:f6 0a:05:df:c4:a8:a3 2e:a7:96:bc:b8:66 36:5c:6c:53:f5:3d a6:b0:1e:7e:87:35 76:89:f8:8b:f0:72 4a:88:eb:2a:8a:29 22:46:26:ab:9c:8f c6:6e:ce:5f:61:d0 d6:fb:8e:0b:2e:91 5a:b2:a1:09:74:7f 8a:ec:e4:13:74:84 8a:ec:71:12:15:74 0e:2a:0b:b2:f6:30 32:5c:8b:85:54:11 fe:20:bf:f1:a9:eb]"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {10.4.4.133 76:70:fd:ad:9c:63 default [10.4.4.133 fe80::7470:fdff:fead:9c63] eth0 domain, guest-agent, multus-status 1}, mac: 76:70:fd:ad:9c:63"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: { da:bb:e8:a6:7e:a9  [] bond0 guest-agent 0}, mac: da:bb:e8:a6:7e:a9"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: { 56:b6:6a:ae:d5:5d  [] dummy0 guest-agent 0}, mac: 56:b6:6a:ae:d5:5d"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {fdae:41e4:649b:9303:f6b1:f698:b096:210 00:00:00:00:00:00  [fdae:41e4:649b:9303:f6b1:f698:b096:210] siderolink domain, guest-agent 0}, mac: 00:00:00:00:00:00"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {fe80::98f9:93ff:fe46:a73e 9a:f9:93:46:a7:3e  [fe80::98f9:93ff:fe46:a73e] cilium_net guest-agent 0}, mac: 9a:f9:93:46:a7:3e"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {10.244.0.220 9e:96:8e:ff:70:f7  [10.244.0.220 fe80::9c96:8eff:feff:70f7] cilium_host guest-agent 0}, mac: 9e:96:8e:ff:70:f7"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {fe80::e0af:67ff:fe16:bfb5 e2:af:67:16:bf:b5  [fe80::e0af:67ff:fe16:bfb5] cilium_vxlan guest-agent 0}, mac: e2:af:67:16:bf:b5"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {fe80::e456:ceff:fe25:8bd5 e6:56:ce:25:8b:d5  [fe80::e456:ceff:fe25:8bd5] lxc_health guest-agent 0}, mac: e6:56:ce:25:8b:d5"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {fe80::182d:2ff:fe35:d7bd 1a:2d:02:35:d7:bd  [fe80::182d:2ff:fe35:d7bd] lxc337c32147b15 guest-agent 0}, mac: 1a:2d:02:35:d7:bd"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {fe80::d048:42ff:fe1f:edca d2:48:42:1f:ed:ca  [fe80::d048:42ff:fe1f:edca] lxc15d6f7b00d91 guest-agent 0}, mac: d2:48:42:1f:ed:ca"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {fe80::b4b8:ebff:feb7:58e9 b6:b8:eb:b7:58:e9  [fe80::b4b8:ebff:feb7:58e9] lxcc18f02aa2727 guest-agent 0}, mac: b6:b8:eb:b7:58:e9"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {fe80::a42b:acff:feb1:f388 a6:2b:ac:b1:f3:88  [fe80::a42b:acff:feb1:f388] lxc3d45b2854b27 guest-agent 0}, mac: a6:2b:ac:b1:f3:88"
time="2024-12-24T02:13:22Z" level=info msg="Current node macs: [96:61:c4:bd:44:df 86:39:76:2a:5b:0e d2:87:e6:c1:44:f6 0a:05:df:c4:a8:a3 2e:a7:96:bc:b8:66 36:5c:6c:53:f5:3d a6:b0:1e:7e:87:35 76:89:f8:8b:f0:72 4a:88:eb:2a:8a:29 22:46:26:ab:9c:8f c6:6e:ce:5f:61:d0 d6:fb:8e:0b:2e:91 5a:b2:a1:09:74:7f 8a:ec:e4:13:74:84 8a:ec:71:12:15:74 0e:2a:0b:b2:f6:30 32:5c:8b:85:54:11 fe:20:bf:f1:a9:eb]"
time="2024-12-24T02:13:22Z" level=info msg="Compared iface: {10.4.4.131 36:5c:6c:53:f5:3d default [10.4.4.131 fe80::345c:6cff:fe53:f53d] eth0 domain, guest-agent, multus-status 1}, mac: 36:5c:6c:53:f5:3d"
time="2024-12-24T02:13:22Z" level=info msg="Discovered Harvester VM node ID" node_id_discovered=pool-xdy-auth-k8s1-c623a657 node_id_original=talos-t4r-bk9
```

