### PR TITLE
fix: handle non-directory entities in /sys/class/net

### DIFF
--- a/pkg/sysfsnet/interfaces_linux.go
+++ b/pkg/sysfsnet/interfaces_linux.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 var sysClassNet = "/sys/class/net"
@@ -23,9 +25,7 @@ func Interfaces() ([]Interface, error) {
 	ifaces := make([]Interface, 0, 16)
 
 	readMACFromFile := func(s string) (string, error) {
-
 		f, err := os.Open(s)
-
 		if os.IsNotExist(err) {
 			return "", nil
 		}
@@ -41,17 +41,15 @@ func Interfaces() ([]Interface, error) {
 	}
 
 	for _, dentry := range dents {
-
 		entryPath := filepath.Join(sysClassNet, dentry.Name())
-
-		// os.Stat to follow symlinks and return the info of the target
-		info, err := os.Stat(entryPath)
+		dinfo, err := os.Stat(entryPath) // stat follows symlinks to directories
 		if err != nil {
+			logrus.Infof("skipping %s. unexpected error: %s", entryPath, err)
 			continue
 		}
 
-		// os.FileInfo.IsDir to check if the entry is a directory
-		if !info.IsDir() {
+		if !dinfo.IsDir() {
+			logrus.Infof("skipping %s: not a directory", entryPath)
 			continue
 		}
 

--- a/pkg/sysfsnet/interfaces_linux.go
+++ b/pkg/sysfsnet/interfaces_linux.go
@@ -25,18 +25,18 @@ func Interfaces() ([]Interface, error) {
 	readMACFromFile := func(s string) (string, error) {
 
 		// Check if parent exists and is a directory
-		parent := filepath.Dir(s)
-		info, err := os.Stat(parent)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return "", nil
-			}
-			return "", err
-		}
+		// parent := filepath.Dir(s)
+		// info, err := os.Stat(parent)
+		// if err != nil {
+		// 	if os.IsNotExist(err) {
+		// 		return "", nil
+		// 	}
+		// 	return "", err
+		// }
 
-		if !info.IsDir() {
-			return "", nil
-		}
+		// if !info.IsDir() {
+		// 	return "", nil
+		// }
 
 		f, err := os.Open(s)
 
@@ -55,6 +55,11 @@ func Interfaces() ([]Interface, error) {
 	}
 
 	for _, dentry := range dents {
+
+		if !dentry.IsDir() {
+			continue
+		}
+
 		hwText, err := readMACFromFile(filepath.Join(sysClassNet, dentry.Name(), "address"))
 		if os.IsNotExist(err) {
 			continue

--- a/pkg/sysfsnet/interfaces_linux.go
+++ b/pkg/sysfsnet/interfaces_linux.go
@@ -24,20 +24,6 @@ func Interfaces() ([]Interface, error) {
 
 	readMACFromFile := func(s string) (string, error) {
 
-		// Check if parent exists and is a directory
-		// parent := filepath.Dir(s)
-		// info, err := os.Stat(parent)
-		// if err != nil {
-		// 	if os.IsNotExist(err) {
-		// 		return "", nil
-		// 	}
-		// 	return "", err
-		// }
-
-		// if !info.IsDir() {
-		// 	return "", nil
-		// }
-
 		f, err := os.Open(s)
 
 		if os.IsNotExist(err) {
@@ -56,11 +42,20 @@ func Interfaces() ([]Interface, error) {
 
 	for _, dentry := range dents {
 
-		if !dentry.IsDir() {
+		entryPath := filepath.Join(sysClassNet, dentry.Name())
+
+		// os.Stat to follow symlinks and return the info of the target
+		info, err := os.Stat(entryPath)
+		if err != nil {
 			continue
 		}
 
-		hwText, err := readMACFromFile(filepath.Join(sysClassNet, dentry.Name(), "address"))
+		// os.FileInfo.IsDir to check if the entry is a directory
+		if !info.IsDir() {
+			continue
+		}
+
+		hwText, err := readMACFromFile(filepath.Join(entryPath, "address"))
 		if os.IsNotExist(err) {
 			continue
 		}

--- a/pkg/sysfsnet/interfaces_linux.go
+++ b/pkg/sysfsnet/interfaces_linux.go
@@ -23,7 +23,23 @@ func Interfaces() ([]Interface, error) {
 	ifaces := make([]Interface, 0, 16)
 
 	readMACFromFile := func(s string) (string, error) {
+
+		// Check if parent exists and is a directory
+		parent := filepath.Dir(s)
+		info, err := os.Stat(parent)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", nil
+			}
+			return "", err
+		}
+
+		if !info.IsDir() {
+			return "", nil
+		}
+
 		f, err := os.Open(s)
+
 		if os.IsNotExist(err) {
 			return "", nil
 		}

--- a/pkg/sysfsnet/interfaces_test.go
+++ b/pkg/sysfsnet/interfaces_test.go
@@ -27,32 +27,35 @@ func TestInterfaces(t *testing.T) {
 		}
 	}
 
-	nonDirPath := filepath.Join(sysClassNet, "bonding_masters")
-	if err := os.WriteFile(nonDirPath, []byte(""), 0o644); err != nil {
-		t.Fatalf("os.WriteFile %q want err=<nil>, got err=%v", nonDirPath, err)
+	// Interfaces() should follow symlinkDir.
+	symlinkDir := filepath.Join(sysClassNet, "eth0_ln")
+	if err := os.Symlink(filepath.Join(sysClassNet, "eth0"), symlinkDir); err != nil {
+		t.Fatalf("os.Symlink %q want err=<nil>, got err=%v", symlinkDir, err)
 	}
 
-	ifaces, err := Interfaces()
+	// Interfaces() should skip non-directories like flatFile and symlinkFile.
+	flatFile := filepath.Join(sysClassNet, "bonding_masters")
+	if err := os.WriteFile(flatFile, []byte("bond1 bond2 bond3"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile %q want err=<nil>, got err=%v", flatFile, err)
+	}
+
+	symlinkFile := filepath.Join(sysClassNet, "bonding_masters_ln")
+	if err := os.Symlink(flatFile, symlinkFile); err != nil {
+		t.Fatalf("os.Symlink %q want err=<nil>, got err=%v", symlinkFile, err)
+	}
+
+	got, err := Interfaces()
 	if err != nil {
 		t.Fatalf("want err=<nil>, got err=%v", err)
 	}
 
-	got := make(map[string]struct{})
-	for _, iface := range ifaces {
-		got[iface.HardwareAddr.String()] = struct{}{}
-	}
-
-	want := map[string]struct{}{
-		"ce:ce:ce:ce:ce:ce": {},
-		"00:00:00:00:00:00": {},
+	want := []Interface{
+		{HardwareAddr: []byte{0xce, 0xce, 0xce, 0xce, 0xce, 0xce}}, // from eth0
+		{HardwareAddr: []byte{0xce, 0xce, 0xce, 0xce, 0xce, 0xce}}, // from eth0_ln
+		{HardwareAddr: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
 	}
 
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("want MACs=%v, got MACs=%v", want, got)
-	}
-
-	// Ensure non-directory entry is ignored
-	if _, exists := got[""]; exists {
-		t.Fatalf("non-directory entry was incorrectly processed")
 	}
 }

--- a/pkg/sysfsnet/interfaces_test.go
+++ b/pkg/sysfsnet/interfaces_test.go
@@ -27,6 +27,11 @@ func TestInterfaces(t *testing.T) {
 		}
 	}
 
+	nonDirPath := filepath.Join(sysClassNet, "bonding_masters")
+	if err := os.WriteFile(nonDirPath, []byte(""), 0o644); err != nil {
+		t.Fatalf("os.WriteFile %q want err=<nil>, got err=%v", nonDirPath, err)
+	}
+
 	ifaces, err := Interfaces()
 	if err != nil {
 		t.Fatalf("want err=<nil>, got err=%v", err)
@@ -44,5 +49,10 @@ func TestInterfaces(t *testing.T) {
 
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("want MACs=%v, got MACs=%v", want, got)
+	}
+
+	// Ensure non-directory entry is ignored
+	if _, exists := got[""]; exists {
+		t.Fatalf("non-directory entry was incorrectly processed")
 	}
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
The CSI driver expects all entries within the `/sys/class/net` folder to be sub-directories or symlinks to sub-directories. If flat files (like [`bonding_masters`](https://lwn.net/Articles/142330/) are found), the driver manager would fail to enumerate interface macs.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Update the driver manager's ifaces discovery loop in `Interfaces()` to explicitly skip all non-folder entries within the `/sys/class/net` folder. There are no changes to existing behaviour where the driver manager only processes sub-directories or symlinks to sub-directories.

**Related Issue:**
https://github.com/harvester/harvester/issues/7232

**Test plan:**
Update unit tests.