### PR TITLE
controller: label guest cluster name to host PVC

### DIFF
--- a/pkg/csi/util.go
+++ b/pkg/csi/util.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	deviceByIDDirectory = "/dev/disk/by-id/"
-	driverName          = "driver.harvesterhci.io"
-	LHName              = "Longhorn"
+	guestClusterNameLabel = "guestcluster.harvesterhci.io/name"
+	deviceByIDDirectory   = "/dev/disk/by-id/"
+	driverName            = "driver.harvesterhci.io"
+	LHName                = "Longhorn"
 )
 
 type volumeFilesystemStatistics struct {


### PR DESCRIPTION
    - It would help us to tidy up.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
We need guest cluster symbol for tidying up when removing the guest cluster

**Solution:**
label the guest cluster name on host PVC

**Related Issue:**
https://github.com/harvester/harvester/issues/7940

**Test plan:**
1. Create guest cluster and update CSI driver with this PR
2. update the harvester-csi-driver RBAC on guest cluster (if you directly update the image)
```
- apiGroups:
  - apps
  resources:
  - deployments
  verbs:
  - get
  - watch
  - list
```
3. create PVC
4. check the host cluster PVC has corresponding label like below:
```
  labels:
    guestcluster.harvesterhci.io/name: <guest cluster name>
```