### PR TITLE
csi/controller: sent remove request to VM instead of VMI

### DIFF
--- a/pkg/csi/controller_server.go
+++ b/pkg/csi/controller_server.go
@@ -662,21 +662,9 @@ func (cs *ControllerServer) ControllerUnpublishVolume(_ context.Context, req *cs
 // or (false, error) if an error occurred.
 func (cs *ControllerServer) removeVolumeFromHostVM(nodeID, volumeID string) (bool, error) {
 
-	// Remove VMI first, because remove from VMI will fail once the volume was removed from VM
 	volumeInVMI, err := cs.checkVolumeExistsInVMI(nodeID, volumeID)
 	if err != nil {
 		return false, err
-	}
-
-	if volumeInVMI {
-		logrus.Infof("Volume %s found in VMI %s (not in VM), sending RemoveVolume request to VMI", volumeID, nodeID)
-		opts := &kubevirtv1.RemoveVolumeOptions{
-			Name: volumeID,
-		}
-		if err := cs.virtClient.VirtualMachineInstance(cs.namespace).RemoveVolume(context.TODO(), nodeID, opts); err != nil {
-			return false, fmt.Errorf("failed to remove volume %s from VMI %s: %w", volumeID, nodeID, err)
-		}
-		return true, nil
 	}
 
 	volumeInVM, err := cs.checkVolumeExistsInVM(nodeID, volumeID)
@@ -684,18 +672,27 @@ func (cs *ControllerServer) removeVolumeFromHostVM(nodeID, volumeID string) (boo
 		return false, err
 	}
 
-	if volumeInVM {
-		logrus.Infof("Volume %s found in VM %s, sending RemoveVolume request to VM", volumeID, nodeID)
-		opts := &kubevirtv1.RemoveVolumeOptions{
-			Name: volumeID,
-		}
+	if !volumeInVM && !volumeInVMI {
+		// Volume doesn't exist in VM or VMI
+		return false, nil
+	}
+
+	opts := &kubevirtv1.RemoveVolumeOptions{
+		Name: volumeID,
+	}
+
+	// Since VMI is owned by VM, we always send the RemoveVolume request to VM
+	// regardless of whether the volume remains in VM or VMI.
+	if volumeInVMI || volumeInVM {
+		logrus.Infof("Volume %s found in VM/VMI %s, sending RemoveVolume request to VM", volumeID, nodeID)
 		if err := cs.virtClient.VirtualMachine(cs.namespace).RemoveVolume(context.TODO(), nodeID, opts); err != nil {
 			return false, fmt.Errorf("failed to remove volume %s from VM %s: %w", volumeID, nodeID, err)
 		}
 		return true, nil
 	}
 
-	// Volume doesn't exist in VM or VMI
+	// Should not reach here because !volumeInVM && !volumeInVMI is handled above,
+	// but keep a safe default.
 	return false, nil
 }
 


### PR DESCRIPTION
    - In our scenario, the VMI was owned by VM. We need to sent request to VM or it would be denied.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Sent request to VMI would be denied, as shown below:
```
failed to remove volume pvc-2ec3a094-67f1-447b-967a-29846c1e1569 from VMI v134-317-v180-pool1-f4kk6-krkkr: VMI default/v134-317-v180-pool1-f4kk6-krkkr is owned by a VM"
```

**Solution:**
Always sent request to VM

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->