### PR TITLE
fix: insufficient permission for external provider guest cluster

### DIFF
--- a/deploy/generate_addon_csi.sh
+++ b/deploy/generate_addon_csi.sh
@@ -18,7 +18,6 @@ if [[ -n "$3" ]]; then
   SCRIPT_TARGET=$3
 fi
 
-
 case $SCRIPT_TARGET in
   RKE1 | rke1 | RKE2 | rke2 | K3S | k3s)
 ;;
@@ -44,12 +43,12 @@ create_target_folder() {
 create_service_account() {
   echo -e "\\nCreating a service account in ${NAMESPACE} namespace: ${SERVICE_ACCOUNT_NAME}"
   # use kubectl apply to ignore AlreadyExists error
-  kubectl create sa "${SERVICE_ACCOUNT_NAME}" --namespace "${NAMESPACE}" --dry-run -o yaml | kubectl apply -f -
+  kubectl create sa "${SERVICE_ACCOUNT_NAME}" --namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 }
 
 create_rolebinding() {
   echo -e "\\nCreating a rolebinding in ${NAMESPACE} namespace: ${ROLE_BINDING_NAME}"
-  kubectl create rolebinding ${ROLE_BINDING_NAME} --serviceaccount=${NAMESPACE}:${SERVICE_ACCOUNT_NAME} --clusterrole=${CLUSTER_ROLE_NAME} --namespace=${NAMESPACE} --dry-run -o yaml | kubectl apply -f -
+  kubectl create rolebinding "${ROLE_BINDING_NAME}" --serviceaccount="${NAMESPACE}:${SERVICE_ACCOUNT_NAME}" --clusterrole="${CLUSTER_ROLE_NAME}" --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 }
 
 get_secret_name_from_service_account() {
@@ -114,7 +113,7 @@ set_kube_config_values() {
   if [ $? -ne 0 ]; then
         echo "ENDPOINT not reachable!"
         exit 1
-  fi  
+  fi
   echo "Endpoint: ${ENDPOINT}"
 
   # Set up the config
@@ -163,7 +162,7 @@ $kubeconfig
   addons_include:
   - https://raw.githubusercontent.com/harvester/harvester-csi-driver/master/deploy/manifests/deployment.yaml
   "
-  rm -rf ${TARGET_FOLDER}
+  rm -rf "${TARGET_FOLDER}"
 }
 
 generate_cloud_config() {
@@ -182,7 +181,7 @@ generate_cloud_config() {
     owner: root:root
     path: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
     permissions: '0644'"
-  rm -r ${TARGET_FOLDER}
+  rm -rf "${TARGET_FOLDER}"
 }
 
 create_target_folder

--- a/deploy/generate_addon_csi.sh
+++ b/deploy/generate_addon_csi.sh
@@ -31,6 +31,7 @@ SERVICE_ACCOUNT_NAME=$1
 NAMESPACE=$2
 ROLE_BINDING_NAME=$NAMESPACE-$SERVICE_ACCOUNT_NAME
 CLUSTER_ROLE_NAME="harvesterhci.io:cloudprovider"
+CSI_DRIVER_ROLE_NAME="harvesterhci.io:csi-driver"
 KUBECFG_FILE_NAME="./tmp/kube/k8s-${SERVICE_ACCOUNT_NAME}-${NAMESPACE}-conf"
 TARGET_FOLDER="./tmp/kube"
 
@@ -49,6 +50,11 @@ create_service_account() {
 create_rolebinding() {
   echo -e "\\nCreating a rolebinding in ${NAMESPACE} namespace: ${ROLE_BINDING_NAME}"
   kubectl create rolebinding "${ROLE_BINDING_NAME}" --serviceaccount="${NAMESPACE}:${SERVICE_ACCOUNT_NAME}" --clusterrole="${CLUSTER_ROLE_NAME}" --namespace="${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+}
+
+create_clusterrolebinding() {
+  echo -e "\\nCreating a clusterrolebinding: ${ROLE_BINDING_NAME}"
+  kubectl create clusterrolebinding "${ROLE_BINDING_NAME}" --serviceaccount="${NAMESPACE}:${SERVICE_ACCOUNT_NAME}" --clusterrole="${CSI_DRIVER_ROLE_NAME}" --dry-run=client -o yaml | kubectl apply -f -
 }
 
 get_secret_name_from_service_account() {
@@ -187,6 +193,7 @@ generate_cloud_config() {
 create_target_folder
 create_service_account
 create_rolebinding
+create_clusterrolebinding
 get_secret_name_from_service_account
 extract_ca_crt_from_secret
 get_user_token_from_secret


### PR DESCRIPTION
**Problem:**

The current guide is outdated: https://docs.harvesterhci.io/v1.8/rancher/csi-driver/#deploy-harvester-csi-driver, I followed the doc and used [generate_addon_csi.sh](https://raw.githubusercontent.com/harvester/harvester-csi-driver/master/deploy/generate_addon_csi.sh) to set up the ServiceAccount and RoleBindings for harvesterhci.io/cloudprovider to setup k3s guest cluster, but it turns out the permissions are insufficient. It's missing get/list access for volumeremotebackups and volumeremoterestore and much more...

**Solution:**

Add csi-driver clusterrolebinding to service account in the generate_addon_csi.sh

**Related Issue:**

related to https://github.com/harvester/harvester/issues/10298

**Test plan:**

1. prepare harvester v1.8 cluster
2. follow this doc https://docs.harvesterhci.io/v1.8/rancher/csi-driver/#deploy-harvester-csi-driver
4. create a k3s guest cluster
5. install volume snapshot https://docs.harvesterhci.io/v1.8/rancher/csi-driver/#volume-snapshots
```
# Apply the VolumeSnapshotClass, VolumeSnapshotContent, and VolumeSnapshot CRDs
kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.5.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.5.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.5.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml

# RBAC permissions for the controller
kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.5.0/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml

# The controller deployment itself
kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v8.5.0/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
```
6. install harvester-csi-driver chart
7. update harvester-csi-driver image version to v0.2.7, you can run below cmd:
  ```
  kubectl set image daemonset/harvester-csi-driver -n kube-system harvester-csi-driver=rancher/harvester-csi-driver:v0.2.7
  ```
8. create a dummy workload in guest cluster
  ```yaml
  apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    name: fs-vol
  spec:
    accessModes:
      - ReadWriteOnce
    volumeMode: Filesystem
    resources:
      requests:
        storage: 2Gi
  ---
  apiVersion: v1
  kind: Pod
  metadata:
    name: pod-fs-vol
  spec:
    containers:
      - name: ubuntu
        image: ubuntu:latest
        command: ["/bin/bash", "-c", "sleep infinity"]
        volumeMounts:
          - name: fs-vol
            mountPath: /data-fs-vol
    volumes:
      - name: fs-vol
        persistentVolumeClaim:
          claimName: fs-vol
  ```
9. The pod runs successfully without issues.