### PR TITLE
chore: bump golang 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # check=skip=InvalidDefaultArgInFrom
 
 # ---- builder ----
-FROM registry.suse.com/bci/golang:1.25.7 AS builder
+FROM registry.suse.com/bci/golang:1.26 AS builder
 
 ARG MK_HOST_ARCH
 ENV ARCH=${MK_HOST_ARCH}
@@ -10,7 +10,7 @@ ENV ARCH=${MK_HOST_ARCH}
 RUN zypper -n rm container-suseconnect && \
     zypper -n install git curl gzip tar wget awk
 
-COPY --from=golangci/golangci-lint:v2.11.4-alpine@sha256:72bcd68512b4e27540dd3a778a1b7afd45759d8145cfb3c089f1d7af53e718e9 \
+COPY --from=golangci/golangci-lint:v2.12.2-alpine@sha256:91b27804074a0bacea298707f016911e60cf0cdbc6c7bf5ccacb5f0606d18d60 \
     /usr/bin/golangci-lint /usr/local/bin/golangci-lint
 
 ENV HOME=/go/src/github.com/harvester/harvester-csi-driver

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester-csi-driver
 
-go 1.25.7
+go 1.26
 
 replace (
 	github.com/google/gnostic-models => github.com/google/gnostic-models v0.6.9

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,6 @@ github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/WebberHuang1118/harvester v0.0.0-20260123064856-f5d26232a2fd h1:ynpCM+BJ/Qcrmt6/tGIWUznvDwVVKIFZ2oOXaU03QpE=
-github.com/WebberHuang1118/harvester v0.0.0-20260123064856-f5d26232a2fd/go.mod h1:j89DN0eSJ7E1XH9isaz6kgYWlajdaMHepdOj1P2ejog=
-github.com/WebberHuang1118/harvester v0.0.0-20260302072803-26473c1be4c7 h1:AmSSPn+0soiIhXHAxS7JF6I2aYk/b4FTtGb71q3cdPo=
-github.com/WebberHuang1118/harvester v0.0.0-20260302072803-26473c1be4c7/go.mod h1:Xmv/kIBGBYaNT2u4m/noOXeaUrwhkjmIOBJQ77H9C6Y=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=


### PR DESCRIPTION
    - also bump golangci-lint 2.12.2

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
bump golang 1.26

**Solution:**
bump golang 1.26

**Related Issue:**
https://github.com/harvester/harvester/issues/10734

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->