### PR TITLE
fix: replace nsenter mount/umount with mount-utils for Talos compatib…

### DIFF
--- a/pkg/csi/node_server.go
+++ b/pkg/csi/node_server.go
@@ -123,13 +123,9 @@ func (ns *NodeServer) nodeStageRWXVolume(req *csi.NodeStageVolumeRequest) (*csi.
 	logrus.Debugf("target args: %v", args)
 
 	// do mount
-	nspace := common.GetHostNamespacePath("/proc")
-	executor, err := cmd.NewExecutorWithNS(nspace)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not create executor: %v", err)
-	}
+	mounter := mount.New("")
 	logrus.Infof("Mounting volume %s to %s", req.VolumeId, stagingTargetPath)
-	_, err = executor.Execute("mount", args)
+	err = mounter.Mount(export, stagingTargetPath, "nfs", strings.Split(mountOpts, ","))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount %v for global path: %v", export, err)
 	}
@@ -149,21 +145,46 @@ func (ns *NodeServer) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageV
 		return nil, status.Errorf(codes.Internal, "Could not create executor: %v", err)
 	}
 
+	mounter := mount.New("")
+
 	logrus.Infof("Unmounting volume %s from %s", req.VolumeId, stagingTargetPath)
-	out, err := executor.Execute("mountpoint", []string{stagingTargetPath})
+	notMount, err := mounter.IsLikelyNotMountPoint(stagingTargetPath)
 	if err != nil {
-		if strings.Contains(err.Error(), "is not a mountpoint") {
+
+		if os.IsNotExist(err) {
 			logrus.Infof("Volume %s is not mounted at %s, return directly.", req.VolumeId, stagingTargetPath)
 			return &csi.NodeUnstageVolumeResponse{}, nil
 		}
-		return nil, status.Errorf(codes.Internal, "Could not check mountpoint %v: %v", stagingTargetPath, err)
-	}
-	if !strings.Contains(out, "is a mountpoint") {
-		return &csi.NodeUnstageVolumeResponse{}, nil
+
+		// Fallback to check mountpoint command
+		logrus.Infof("Failed to check mountpoint %v: %v, fallback to check mountpoint command", stagingTargetPath, err)
+
+		out, err := executor.Execute("mountpoint", []string{stagingTargetPath})
+		if err != nil {
+			if strings.Contains(err.Error(), "is not a mountpoint") {
+				logrus.Infof("Volume %s is not mounted at %s, return directly.", req.VolumeId, stagingTargetPath)
+				return &csi.NodeUnstageVolumeResponse{}, nil
+			}
+			return nil, status.Errorf(codes.Internal, "Could not check mountpoint %v: %v", stagingTargetPath, err)
+		}
+		if !strings.Contains(out, "is a mountpoint") {
+			return &csi.NodeUnstageVolumeResponse{}, nil
+		}
+
+		notMount = false
+
 	}
 
-	if _, err := executor.Execute("umount", []string{stagingTargetPath}); err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not unmount %v: %v", stagingTargetPath, err)
+	if !notMount {
+		err := mounter.Unmount(stagingTargetPath)
+		if err != nil {
+			// Fallback to umount command
+			logrus.Infof("Failed to unmount %v: %v, fallback to umount command", stagingTargetPath, err)
+
+			if _, err := executor.Execute("umount", []string{stagingTargetPath}); err != nil {
+				return nil, status.Errorf(codes.Internal, "Could not unmount %v: %v", stagingTargetPath, err)
+			}
+		}
 	}
 
 	return &csi.NodeUnstageVolumeResponse{}, nil


### PR DESCRIPTION
**Problem:**
The unmount requires the host system to have the mountpoint binary. While it is available inside the harvester csi image.

Logs:
```
time="2026-06-12T15:01:03Z" level=info msg="GRPC call: /csi.v1.Node/NodeUnstageVolume request: {\"staging_target_path\":\"/var/lib/kubelet/plugins/kubernetes.io/csi/driver.harvesterhci.io/d61598db2234a1f680a076e385b4a486e9696fed12e32b0598de6977e1429fa1/globalmount\",\"volume_id\":\"pvc-73d8b0b2-198a-4317-ba3d-0b5e5313ef32\"}"
time="2026-06-12T15:01:03Z" level=info msg="Unmounting volume pvc-73d8b0b2-198a-4317-ba3d-0b5e5313ef32 from /var/lib/kubelet/plugins/kubernetes.io/csi/driver.harvesterhci.io/d61598db2234a1f680a076e385b4a486e9696fed12e32b0598de6977e1429fa1/globalmount"
time="2026-06-12T15:01:03Z" level=error msg="GRPC error: rpc error: code = Internal desc = Could not check mountpoint /var/lib/kubelet/plugins/kubernetes.io/csi/driver.harvesterhci.io/d61598db2234a1f680a076e385b4a486e9696fed12e32b0598de6977e1429fa1/globalmount: failed to execute: nsenter [--mount=/proc/7042/ns/mnt --net=/proc/7042/ns/net --ipc=/proc/7042/ns/ipc mountpoint /var/lib/kubelet/plugins/kubernetes.io/csi/driver.harvesterhci.io/d61598db2234a1f680a076e385b4a486e9696fed12e32b0598de6977e1429fa1/globalmount], output , stderr nsenter: failed to execute mountpoint: No such file or directory\n: exit status 127"
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Instead of relying on the host system to have the mountpoint binary use the mountpoint binary that is available inside the container.

Inspired by: ganawaj/harvester-csi-driver@change-deps


**Related Issue:** https://github.com/harvester/harvester/issues/10874

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->